### PR TITLE
Add a Relative Paper Id to Project Papers

### DIFF
--- a/proto/main.proto
+++ b/proto/main.proto
@@ -95,6 +95,7 @@ service SnowballR {
 
 
   rpc GetProjectPaperById (Id) returns (Project.Paper);
+  rpc GetProjectPaperByRelativeId (Project.Paper.Get) returns (Project.Paper);
   rpc GetAllProjectPapersForProject (Id) returns (Project.Paper.List);
   rpc AddPaperToProject (Project.Paper.Add) returns (Project.Paper);
   // Update the project paper with the given id using the provided data. Only

--- a/proto/project.proto
+++ b/proto/project.proto
@@ -92,10 +92,16 @@ message Project {
 
   message Paper {
     string id = 1;
+    string local_id = 6;
     snowballr.Paper paper = 2;
     uint64 stage = 3;
     PaperDecision decision = 4;
     repeated Review reviews = 5;
+
+    message Get {
+      string project_id = 1;
+      string relative_project_paper_id = 2;
+    }
 
     message List {
       repeated Paper project_papers = 1;


### PR DESCRIPTION
Fixes #9.

Introduces `Paper.Project.relative_id` and `GetProjectPaperByRelativeId`.

Documentation will follow soon in #3.
