### PR TITLE
Add Ability to Change Project Member Rank

### DIFF
--- a/proto/main.proto
+++ b/proto/main.proto
@@ -83,6 +83,7 @@ service SnowballR {
   rpc SoftUndeleteProject (Id) returns (Nothing);
   rpc GetProjectStatistics (Project.Statistics.Get)
     returns (Project.Statistics);
+  rpc UpdateProjectMemberRole (Project.Member.Update) returns (Nothing);
 
   
   rpc GetCriterionById (Id) returns (Criterion);

--- a/proto/project.proto
+++ b/proto/project.proto
@@ -88,6 +88,12 @@ message Project {
       string project_id = 1;
       string user_id = 2;
     }
+
+    message Update {
+      string project_id = 1;
+      string user_id = 2;
+      MemberRole new_role = 3;
+    }
   }
 
   message Paper {


### PR DESCRIPTION
Fixes #6, instead of adding a promote function though, an update function for a member's rank is implemented which also allows the demotion of a member. This might also be more suitable in case another role is being added.