### PR TITLE
Step towards HttpOnly Cookie Auth

### DIFF
--- a/proto/authentication.proto
+++ b/proto/authentication.proto
@@ -27,3 +27,13 @@ message PasswordChangeRequest {
   string new_password = 2;
 }
 
+enum AuthenticationStatus {
+  AUTHENTICATION_STATUS_UNSPECIFIED = 0;
+  AUTHENTICATION_STATUS_UNAUTHENTICATED = 1;
+  AUTHENTICATION_STATUS_ACCESS_TOKEN_EXPIRED = 2;
+  AUTHENTICATION_STATUS_AUTHENTICATED = 3;
+}
+
+message AuthenticationStatusResponse {
+  AuthenticationStatus authentication_status = 1;
+}

--- a/proto/authentication.proto
+++ b/proto/authentication.proto
@@ -6,20 +6,11 @@ message LoginRequest {
   string password = 2;
 }
 
-message LoginSecret {
-  string access_token = 1;
-  string refresh_token = 2;
-}
-
 message RegisterRequest {
   string first_name = 1;
   string last_name = 2;
   string email = 3;
   string password = 4;
-}
-
-message RenewRequest {
-  string refresh_token = 1;
 }
 
 message RequestPasswordResetRequest {

--- a/proto/main.proto
+++ b/proto/main.proto
@@ -15,11 +15,11 @@ service SnowballR {
   rpc GetAvailableFetcherApis (Nothing) returns (AvailableFetcherApis);
   
 
-  rpc Register (RegisterRequest) returns (LoginSecret);
-  rpc Login (LoginRequest) returns (LoginSecret);
+  rpc Register (RegisterRequest) returns (Nothing);
+  rpc Login (LoginRequest) returns (Nothing);
   rpc Logout (Nothing) returns (Nothing);
   rpc IsAuthenticated (Nothing) returns (BoolValue);
-  rpc RenewSession (RenewRequest) returns (LoginSecret);
+  rpc RenewSession (Nothing) returns (Nothing);
   rpc RequestPasswordReset (RequestPasswordResetRequest) returns (Nothing);
   // Request an email from the server to help you reset your password
   // in case you forgot it.

--- a/proto/main.proto
+++ b/proto/main.proto
@@ -18,7 +18,7 @@ service SnowballR {
   rpc Register (RegisterRequest) returns (Nothing);
   rpc Login (LoginRequest) returns (Nothing);
   rpc Logout (Nothing) returns (Nothing);
-  rpc IsAuthenticated (Nothing) returns (BoolValue);
+  rpc GetAuthenticationStatus (Nothing) returns (AuthenticationStatusResponse);
   rpc RenewSession (Nothing) returns (Nothing);
   rpc RequestPasswordReset (RequestPasswordResetRequest) returns (Nothing);
   // Request an email from the server to help you reset your password


### PR DESCRIPTION
`LoginSecret` is not needed because the tokens should only be accessible through http and not javascript.
After this is merged, #13 will be rebased and updated accordingly.

See SE-UUlm/snowballr-frontend#220, SE-UUlm/snowballr-mock-backend#12