### PR TITLE
feat: add methods to get next and previous paper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .direnv/
+.idea/

--- a/proto/main.proto
+++ b/proto/main.proto
@@ -105,6 +105,8 @@ service SnowballR {
   // specified fields will be updated.
   rpc UpdateProjectPaper (Project.Paper.Update) returns (Project.Paper);
   rpc RemovePaperFromProject (Id) returns (Nothing);
+  rpc GetNextProjectPaper (Id) returns (Project.Paper);
+  rpc GetPreviousProjectPaper (Id) returns (Project.Paper);
 
 
   rpc GetReviewById (Id) returns (Review);

--- a/proto/main.proto
+++ b/proto/main.proto
@@ -45,7 +45,22 @@ service SnowballR {
   rpc GetAllPapersToReview (Nothing) returns (Project.Paper.List);
   // Get all papers from a specific project the requesting user should review.
   rpc GetPapersToReviewForProject (Id) returns (Project.Paper.List);
-  
+  // Get the paper with the succeeding local id
+  rpc GetNextPaper (Id) returns (Project.Paper);
+  // Get the paper with the succeeding local id, that still has to be in
+  // review and is on the same stage. If there is no other paper to be
+  // reviewed on the same page, the same criteria counts for the next
+  // stage and so on until there is no other paper to review in the
+  // same stage and higher stages
+  rpc GetNextPaperToReview (Id) returns (Project.Paper);
+  // Get the paper with the preceding local id
+  rpc GetPreviousPaper (Id) returns (Project.Paper);
+  // Get the previous paper with the preceding local id that still has
+  // to be in review and is on the same stage. If there is no other paper
+  // to be reviewed on the same page, the same criteria counts for the
+  // previous stage and so on until there is no other paper to review in
+  // the same stage and lower stages
+  rpc GetPreviousPaperToReview (Id) returns (Project.Paper);
 
   rpc GetUserSettings (Nothing) returns (UserSettings);
   rpc UpdateUserSettings (UserSettings.Update) returns (UserSettings);
@@ -105,8 +120,6 @@ service SnowballR {
   // specified fields will be updated.
   rpc UpdateProjectPaper (Project.Paper.Update) returns (Project.Paper);
   rpc RemovePaperFromProject (Id) returns (Nothing);
-  rpc GetNextProjectPaper (Id) returns (Project.Paper);
-  rpc GetPreviousProjectPaper (Id) returns (Project.Paper);
 
 
   rpc GetReviewById (Id) returns (Review);

--- a/proto/project.proto
+++ b/proto/project.proto
@@ -147,7 +147,7 @@ message Project {
 message ReviewDecisionMatrix {
   message Pattern {
     repeated Entry entries = 1;
-    PaperDecision decision = 2; 
+    PaperDecision decision = 2;
 
     message Entry {
       ReviewDecision review_decision = 1;


### PR DESCRIPTION
Closes #23 

## What I have made

Added the two methods to get the next/previous paper.

## Checklist

- ~~[ ] I have updated the documentation accordingly and commented my code~~ only created the two methods, which are self describing
- [ ] (for reviewer) I have checked the implementation against the requirements
