### PR TITLE
Add Build And Run Recipes To Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -6,3 +6,16 @@ lint:
 
 fix:
     protolint -fix {{PROTO_FILES}}
+
+build-docs:
+    docker build . -t "snowballr-api/docs"
+
+run-docs open="true": build-docs
+    #!/usr/bin/env bash
+    docker run --rm -p 8080:80 "snowballr-api/docs" &
+    pid=$!
+    if [ "{{open}}" = "true" ]; then \
+        sleep 1
+        open "http://localhost:8080"; \
+    fi
+    wait $pid


### PR DESCRIPTION
## What I have made

Added the following recipes to the justfile:
```
just build-docs
just run-docs        # defaults to opening the documentation
just run-docs false  # prevents opening the documentation
```

These commands build and run the docker image.