### PR TITLE
Fix List Styling for Unordered Lists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY . .
 RUN cd proto && protoc *.proto -o ../descriptor.pb --include_source_info
 RUN pip3 install pypatch markdown-mermaidjs
 RUN pypatch apply ./patches/sabledocs_fix_nested.patch sabledocs
+RUN pypatch apply ./patches/sabledocs_styles.patch sabledocs
 RUN pypatch apply ./patches/sabledocs_mermaid_theme_change.patch sabledocs
 RUN pypatch apply ./patches/markdown_mermaidjs_no_script.patch markdown_mermaidjs
 RUN sabledocs

--- a/patches/sabledocs_styles.patch
+++ b/patches/sabledocs_styles.patch
@@ -1,0 +1,10 @@
+diff --git a/templates/_default/static/mystyles.css b/templates/_default/static/mystyles.css
+index ca8591b..9b045d2 100644
+--- a/templates/_default/static/mystyles.css
++++ b/templates/_default/static/mystyles.css
+@@ -1,1 +1,5 @@
++ ul {
++   list-style: unset !important;
++   padding-left: 2.5em !important;
++ }
+  /*! bulma.io v0.9.4 | MIT License | github.com/jgthms/bulma */


### PR DESCRIPTION
Currently, unordered lists don't have bullet point symbols or padding.

## What I have made

- Added a patch to change the styles
- Set `list-style` to `unset` (filled round circles for me)
- Set `padding-left` to `2.5em`
