### PR TITLE
Remove `GetPreviousPaperToReview` call

### DIFF
--- a/proto/main.proto
+++ b/proto/main.proto
@@ -244,10 +244,6 @@ service SnowballR {
   // paper is the first paper in the project, a `NOT_FOUND` error is returned.
   rpc GetPreviousPaper (Id) returns (Project.Paper);
 
-  // Will be deleted in the future.
-  // See: https://github.com/SE-UUlm/snowballr-api/issues/29
-  rpc GetPreviousPaperToReview (Id) returns (Project.Paper);
-
 
   // Get the list of papers on the reading list of the calling user.
   rpc GetReadingList (Nothing) returns (Paper.List);
@@ -383,7 +379,7 @@ service SnowballR {
   
   // Create a new criterion. Every field **must be specified** and
   // **non-empty**, otherwise an `INVALID_ARGUMENT` error is returned. If
-  // successfull, the newly created criterion is returned.
+  // successful, the newly created criterion is returned.
   // The calling user is **required to be a project admin**.
   rpc CreateCriterion (Criterion.Create) returns (Criterion);
   


### PR DESCRIPTION
Closes #29

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new call, which does x -->

- I removed the `GetPreviousPaperToReview` as we decided to show the last viewed paper, if the user is in review mode. This can be handled in the frontend, thus this method is not necessarry anymore. 
- to get the previous paper if not in review mode only use `GetPreviousPaper`

## Checklist

- [x] I have updated the documentation accordingly and commented my code
- [ ] (for reviewer) I have checked the implementation against the requirements
