### PR TITLE
Add 'GetInviteCandidates' RPC

### DIFF
--- a/proto/main.proto
+++ b/proto/main.proto
@@ -427,6 +427,17 @@ service SnowballR {
   // | `PERMISSION_DENIED` | The user is not allowed to view the invitations of the specified user. |
   rpc GetPendingInvitationsForUser(Id) returns (Project.List);
 
+  // Get a list of user that match the search query and can be invited. If no user matches the search query, then
+  // the returned list if empty.
+  //
+  // ## Errors
+  // | Error Code | Description |
+  // | :--- | :--- |
+  // | `INVALID_ARGUMENT` | The query is empty or too short or the requested number of results exceeds the allowed maximum. |
+  // | `RESOURCE_EXHAUSTED` | Too many search requests. |
+  // | `UNAUTHENTICATED` | The user is not signed in. |
+  rpc GetInviteCandidates(User.SearchQuery) returns (User.List);
+
   // Invite a user to a project. The provided project has to be active, meaning
   // it is neither deleted nor archived. If a user with the provided email
   // already exists, an invitation is sent. The user is **not** instantly added

--- a/proto/main.proto
+++ b/proto/main.proto
@@ -427,14 +427,13 @@ service SnowballR {
   // | `PERMISSION_DENIED` | The user is not allowed to view the invitations of the specified user. |
   rpc GetPendingInvitationsForUser(Id) returns (Project.List);
 
-  // Get a list of user that match the search query and can be invited. If no user matches the search query, then
-  // the returned list if empty.
+  // Get a list of users that match the search query and can be invited.
+  // If no user matches the search query or the query is too short,
+  // then the returned list of users is empty.
   //
   // ## Errors
   // | Error Code | Description |
   // | :--- | :--- |
-  // | `INVALID_ARGUMENT` | The query is empty or too short or the requested number of results exceeds the allowed maximum. |
-  // | `RESOURCE_EXHAUSTED` | Too many search requests. |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   rpc GetInviteCandidates(User.SearchQuery) returns (User.List);
 

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -35,4 +35,15 @@ message User {
     User user = 1;
     google.protobuf.FieldMask mask = 2;
   }
+
+  message SearchQuery {
+    // The search query to match users by name or email.
+    // The query must be at least 3 characters long and matches
+    // users using the algorithm of the FZF tool.
+    string query = 1;
+
+    // Maximum number of results to return (default: 5, max: 20).
+    // Use this to control the result list size in autocomplete scenarios.
+    int32 max_results = 2;
+  }
 }

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -38,12 +38,7 @@ message User {
 
   message SearchQuery {
     // The search query to match users by name or email.
-    // The query must be at least 3 characters long and matches
-    // users using the algorithm of the FZF tool.
+    // The query must be at least 3 characters long.
     string query = 1;
-
-    // Maximum number of results to return (default: 5, max: 20).
-    // Use this to control the result list size in autocomplete scenarios.
-    int32 max_results = 2;
   }
 }


### PR DESCRIPTION
Closes #50

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new call, which does x -->

- I added a new call `GetInviteCandidates` that should be used to search for candidates to invite into a project
  - This call should replace the `GetAllUsers` call in the frontend used when finding suggestions of candidates to invite into a project when creating one

## Checklist

- [x] I have updated the documentation accordingly and commented my code
- [x] (for reviewer) I have checked the implementation against the requirements
