### PR TITLE
add a symbol to all calls that require authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN pip3 install pypatch markdown-mermaidjs \
     && pypatch apply ./patches/sabledocs_nested_links.patch sabledocs \
     && pypatch apply ./patches/sabledocs_nested_names.patch sabledocs \
     && pypatch apply ./patches/sabledocs_fix_arguments.patch sabledocs \
+    && pypatch apply ./patches/sabledocs_auth_tag.patch sabledocs \
     && pypatch apply ./patches/markdown_mermaidjs_no_script.patch markdown_mermaidjs \
     && sabledocs
 

--- a/docs/service.html
+++ b/docs/service.html
@@ -13,14 +13,21 @@
 
 {% for method in service.methods %}
 <div class="box">
-  <div class="block">
-    <h5 class="title is-5" id="service-{{ service.full_name }}-{{ method.name }}">
-      <a href="#service-{{ service.full_name }}-{{ method.name }}">
-        rpc <code>{{ method.name }}</code>
-      </a>
-    </h5>
-    Request: <code>{{ common.type_name(method.request) | trim }}</code><br>
-    Response: <code>{{ common.type_name(method.response) }}</code><br>
+  <div class="auth-sidebyside">
+    <div class="block">
+      <h5 class="title is-5" id="service-{{ service.full_name }}-{{ method.name }}">
+        <a href="#service-{{ service.full_name }}-{{ method.name }}">
+          rpc <code>{{ method.name }}</code>
+        </a>
+      </h5>
+      Request: <code>{{ common.type_name(method.request) | trim }}</code><br>
+      Response: <code>{{ common.type_name(method.response) }}</code><br>
+    </div>
+    {% if method.auth %}
+      <span class="auth-padlock" title="This call requires the user to be authenticated.">
+        <i class="fa-solid fa-lock"></i>
+      </span>
+    {% endif %}
   </div>
 
   {% if method.description_html %}

--- a/docs/static/mystyles.css
+++ b/docs/static/mystyles.css
@@ -49,6 +49,21 @@ table tbody tr:nth-child(odd) {
   background-color: var(--table-row-odd) !important;
 }
 
+.auth-sidebyside {
+  display: flex;
+  flex-direction: row;
+}
+
+.auth-sidebyside .block {
+  flex: 1;
+}
+
+.auth-sidebyside .auth-padlock {
+  display: flex;
+  padding-left: 0.5em;
+  font-size: 1.5em;
+}
+
 /*! bulma.io v0.9.4 | MIT License | github.com/jgthms/bulma */
 /* Bulma Utilities */
 @import "https://unpkg.com/open-props/easings.min.css";

--- a/patches/sabledocs_auth_tag.patch
+++ b/patches/sabledocs_auth_tag.patch
@@ -1,0 +1,25 @@
+diff --git a/proto_descriptor_parser.py b/proto_descriptor_parser.py
+index 062dc84..b7ac025 100644
+--- a/proto_descriptor_parser.py
++++ b/proto_descriptor_parser.py
+@@ -228,6 +228,7 @@ def parse_service_method(service_method: MethodDescriptorProto, ctx: ParseContex
+     sm = ServiceMethod()
+     sm.name = service_method.name
+     sm.description = ctx.config.comments_parser.ParseServiceMethod(ctx.GetComments())
+-    sm.description_html = markdown_to_html(sm.description, ctx.config)
++    sm.auth = "@auth" in sm.description
++    sm.description_html = markdown_to_html(sm.description.replace("@auth", ""), ctx.config)
+     sm.line_number = ctx.GetLineNumber()
+     sm.request = ServiceMethodArgument(
+diff --git a/proto_model.py b/proto_model.py
+index 0edcce8..8d81df4 100644
+--- a/proto_model.py
++++ b/proto_model.py
+@@ -99,6 +99,7 @@ class ServiceMethod(CodeItem):
+         CodeItem.__init__(self)
+         self.request = ServiceMethodArgument("", "", "")
+         self.response = ServiceMethodArgument("", "", "")
++        self.auth = False
+ 
+ 
+ class Service(CodeItem):

--- a/proto/main.proto
+++ b/proto/main.proto
@@ -19,10 +19,11 @@ import "user_settings.proto";
 // This service represents all available interactions between this frontend and
 // backend.
 //
-// Unless stated otherwise, **every** call **requires** the user to be
-// **authenticated**. This will happen automatically using a http-only cookie
-// set by the server during registration or login. If failing to do so, an
-// `UNAUTHENTICATED` error will be returned.
+// The padlock icon in the top right of a service method description indicates
+// whether a call **requires** the user to be **authenticated**. This will
+// happen automatically using a http-only cookie set by the server during
+// registration or login. If failing to do so, an `UNAUTHENTICATED` error will
+// be returned.
 //
 // Furthermore, the server may respond at any time with the `UNAVAILABLE` error
 // code if it is unable to process a request.
@@ -106,6 +107,8 @@ service SnowballR {
   //
   // ## Errors
   // No additional errors may occur.
+  //
+  // @auth
   rpc GetAvailableFetcherApis(Nothing) returns (AvailableFetcherApis);
 
   // Create an account. The provided email **must not be already registered**
@@ -120,8 +123,6 @@ service SnowballR {
   // - contain at least **two digits**,
   // - and contain at least **two special characters**.
   //
-  // This call does not require the user to be authenticated.
-  //
   // ## Errors
   // | Error Code | Description |
   // | :--- | :--- |
@@ -133,8 +134,6 @@ service SnowballR {
   // new set of login tokens is provided to authenticate as that user. Old
   // access and refresh tokens shall remain valid. These credentials are handled
   // automatically and do not need further attention.
-  //
-  // This call does not require the user to be authenticated.
   //
   // ## Errors
   // | Error Code | Description |
@@ -148,12 +147,12 @@ service SnowballR {
   //
   // ## Errors
   // No additional errors may occur.
+  //
+  // @auth
   rpc Logout(Nothing) returns (Nothing);
 
   // Acquire the client's authentication status. The result is **guaranteed** to
   // be **specified**.
-  //
-  // This call does not require the user to be authenticated.
   //
   // ## Errors
   // No additional errors may occur.
@@ -174,6 +173,8 @@ service SnowballR {
   // | Error Code | Description |
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The refresh token is invalid. |
+  //
+  // @auth
   rpc RenewSession(Nothing) returns (Nothing);
 
   // If the provided email address is registered as an active user, a
@@ -181,8 +182,6 @@ service SnowballR {
   // alongside a new password
   // (see [ResetPassword](#service-snowballr.SnowballR-ResetPassword)) in order
   // to update a lost or forgotten password.
-  //
-  // This call does not require the user to be authenticated.
   //
   // ## Errors
   // | Error Code | Description |
@@ -196,8 +195,6 @@ service SnowballR {
   // ownership of the account, the token sent via email must also be provided
   // and valid. The new password must follow the same rules as during
   // [registration](#service-snowballr.SnowballR-Register).
-  //
-  // This call does not require the user to be authenticated.
   //
   // ## Errors
   // | Error Code | Description |
@@ -217,6 +214,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `INVALID_ARGUMENT` | The provided old password is not correct or the new password does not meet the rules specified in `Register`. |
   // | `UNAUTHENTICATED` | The user is not signed in. |
+  //
+  // @auth
   rpc ChangePassword(PasswordChangeRequest) returns (Nothing);
 
   // Get all registered users.
@@ -226,6 +225,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `PERMISSION_DENIED` | The user is not an admin. |
   // | `UNAUTHENTICATED` | The user is not signed in. |
+  //
+  // @auth
   rpc GetAllUsers(Nothing) returns (User.List);
 
   // Get the currently authenticated user by looking up the provided access
@@ -236,6 +237,8 @@ service SnowballR {
   // | Error Code | Description |
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
+  //
+  // @auth
   rpc GetCurrentUser(Nothing) returns (User);
 
   // Get a user by its id.
@@ -245,6 +248,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No user with the provided id was found. |
+  //
+  // @auth
   rpc GetUserById(Id) returns (User);
 
   // Get the user with the specified email address.
@@ -255,6 +260,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No user with the provided email was found. |
   // | `INVALID_ARGUMENT` | The email was invalid. |
+  //
+  // @auth
   rpc GetUserByEmail (Email) returns (User);
 
   // Update all in the field-mask specified attributes of the user with the
@@ -270,6 +277,8 @@ service SnowballR {
   // | `INVALID_ARGUMENT` | The first name, last name, role or email was invalid. |
   // | `PERMISSION_DENIED` | The user is not allowed to modify the user with the specified id. |
   // | `ALREADY_EXISTS` | The updated email is already registered. |
+  //
+  // @auth
   rpc UpdateUser(User.Update) returns (User);
 
   // Prevent the user with the provided id from logging in. It is not fully
@@ -283,6 +292,8 @@ service SnowballR {
   // | `NOT_FOUND` | No user with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not allowed to delete the user with the specified id. |
   // | `FAILED_PRECONDITION` | The user to be deleted is an admin. |
+  //
+  // @auth
   rpc SoftDeleteUser(Id) returns (Nothing);
 
   // Allow a previously soft-deleted user to login again.
@@ -294,6 +305,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No user with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not allowed to restore the user with the specified id. |
+  //
+  // @auth
   rpc SoftUndeleteUser(Id) returns (Nothing);
 
   // Get the user-specific settings for the calling user. It is **guaranteed**
@@ -303,6 +316,8 @@ service SnowballR {
   // | Error Code | Description |
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
+  //
+  // @auth
   rpc GetUserSettings(Nothing) returns (UserSettings);
 
   // Update all in the field-mask specified attributes of the calling user's
@@ -314,6 +329,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `INVALID_ARGUMENT` | The updated settings are invalid. |
+  //
+  // @auth
   rpc UpdateUserSettings(UserSettings.Update) returns (UserSettings);
 
   // Get all project papers the requesting user is able to review. It is not
@@ -324,6 +341,8 @@ service SnowballR {
   // | Error Code | Description |
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
+  //
+  // @auth
   rpc GetAllPapersToReview(Nothing) returns (Project.Paper.List);
 
   // Get all project papers from a specific project identified by the id, the
@@ -336,6 +355,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not a member of the specified project or is not allowed to review. |
+  //
+  // @auth
   rpc GetPapersToReviewForProject(Id) returns (Project.Paper.List);
 
   // Get the project paper with the succeeding _local_ id of the project paper
@@ -349,6 +370,8 @@ service SnowballR {
   // | `NOT_FOUND` | No paper with the provided id was found. |
   // | `FAILED_PRECONDITION` | There was no next paper. |
   // | `PERMISSION_DENIED` | The user is not a member of the specified project. |
+  //
+  // @auth
   rpc GetNextPaper(Id) returns (Project.Paper);
 
   // Get the next project paper the calling user is able to review. Papers with
@@ -362,6 +385,8 @@ service SnowballR {
   // | `NOT_FOUND` | No paper with the provided id was found. |
   // | `FAILED_PRECONDITION` | There was no next paper available to review. |
   // | `PERMISSION_DENIED` | The user is not a member of the specified project or is not allowed to review. |
+  //
+  // @auth
   rpc GetNextPaperToReview(Id) returns (Project.Paper);
 
   // Get the project paper with the preceding _local_ id of the project paper
@@ -375,6 +400,8 @@ service SnowballR {
   // | `NOT_FOUND` | No paper with the provided id was found. |
   // | `FAILED_PRECONDITION` | There was no previous paper. |
   // | `PERMISSION_DENIED` | The user is not a member of the specified project. |
+  //
+  // @auth
   rpc GetPreviousPaper(Id) returns (Project.Paper);
 
   // Get the list of papers on the reading list of the calling user.
@@ -383,6 +410,8 @@ service SnowballR {
   // | Error Code | Description |
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
+  //
+  // @auth
   rpc GetReadingList(Nothing) returns (Paper.List);
 
   // Return whether the paper with the provided id is on the calling
@@ -393,6 +422,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | The specified paper does not exist. |
+  //
+  // @auth
   rpc IsPaperOnReadingList(Id) returns (BoolValue);
 
   // Add the paper with the provided id to the calling user's reading list. If
@@ -404,6 +435,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No paper with the provided id was found. |
+  //
+  // @auth
   rpc AddPaperToReadingList(Id) returns (Nothing);
 
   // Remove the paper with the provided id from the calling user's reading
@@ -414,6 +447,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | The specified paper does not exist. |
+  //
+  // @auth
   rpc RemovePaperFromReadingList(Id) returns (Nothing);
 
   // Get a list of all projects to which the user with the provided id is
@@ -425,6 +460,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No user with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not allowed to view the invitations of the specified user. |
+  //
+  // @auth
   rpc GetPendingInvitationsForUser(Id) returns (Project.List);
 
   // Get a list of users that match the search query and can be invited.
@@ -435,6 +472,8 @@ service SnowballR {
   // | Error Code | Description |
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
+  //
+  // @auth
   rpc GetInviteCandidates(User.SearchQuery) returns (User.List);
 
   // Invite a user to a project. The provided project has to be active, meaning
@@ -454,6 +493,8 @@ service SnowballR {
   // | `FAILED_PRECONDITION` | The project is not active, meaning it is either archived or deleted. |
   // | `PERMISSION_DENIED` | The user is not allowed to invite users to the specified project. |
   // | `INVALID_ARGUMENT` | The provided email is not a valid email address. |
+  //
+  // @auth
   rpc InviteUserToProject(Project.Member.Invite) returns (Nothing);
 
   // Get a list of all users with a pending invitation to the provided project.
@@ -467,6 +508,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not allowed to view the pending invitations of the specified project. |
+  //
+  // @auth
   rpc GetPendingInvitationsForProject(Id) returns (User.List);
 
   // Get a list of all members of the specified project. The calling user is
@@ -478,6 +521,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not allowed to view the members of the specified project. |
+  //
+  // @auth
   rpc GetProjectMembers(Id) returns (Project.Member.List);
 
   // Remove the specified user from the given project. If the user is not part
@@ -491,6 +536,8 @@ service SnowballR {
   // | `NOT_FOUND` | No project with the provided project id or user with the provided user id was found. |
   // | `PERMISSION_DENIED` | The user is not allowed to remove the specified user from the project. |
   // | `FAILED_PRECONDITION` | The user to be removed is the last project admin. |
+  //
+  // @auth
   rpc RemoveProjectMember(Project.Member.Remove) returns (Nothing);
 
   // Change the role of the user with the provided id within the given project.
@@ -505,6 +552,8 @@ service SnowballR {
   // | `PERMISSION_DENIED` | The user is not allowed to change the role of the specified user in the project. This could for example be the case if trying to demote a project admin. |
   // | `NOT_FOUND` | No project with the provided id or user with the provided id was found. |
   // | `FAILED_PRECONDITION` | The user to be updated is not a member of the specified project. |
+  //
+  // @auth
   rpc UpdateProjectMemberRole(Project.Member.Update) returns (Nothing);
 
   // Get a list of all active projects.
@@ -514,6 +563,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `PERMISSION_DENIED` | The user is not allowed to view all global projects. |
+  //
+  // @auth
   rpc GetAllProjects(Nothing) returns (Project.List);
 
   // Get a list of all projects that are marked as deleted.
@@ -523,6 +574,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `PERMISSION_DENIED` | The user is not allowed to view all global deleted projects. |
+  //
+  // @auth
   rpc GetAllDeletedProjects(Nothing) returns (Project.List);
 
   // Get a list of all projects the provided user is a member of and that are
@@ -534,6 +587,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No user with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not allowed to view the deleted projects of the specified user. |
+  //
+  // @auth
   rpc GetAllDeletedProjectsForUser(Id) returns (Project.List);
 
   // Get a list of all projects that are marked as archived.
@@ -543,6 +598,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `PERMISSION_DENIED` | The user is not allowed to view all global archived projects. |
+  //
+  // @auth
   rpc GetAllArchivedProjects(Nothing) returns (Project.List);
 
   // Get a list of all active projects the provided user is a member of. Pending
@@ -554,6 +611,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No user with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not allowed to view the projects of the specified user. |
+  //
+  // @auth
   rpc GetAllProjectsForUser(Id) returns (Project.List);
 
   // Get a list of all projects the provided user is a member of and that are
@@ -565,6 +624,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No user with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not allowed to view the archived projects of the specified user. |
+  //
+  // @auth
   rpc GetAllArchivedProjectsForUser(Id) returns (Project.List);
 
   // Create a new project. Every field must be **specified** and **non-blank**.
@@ -577,6 +638,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `INVALID_ARGUMENT` | The provided project name was blank. |
+  //
+  // @auth
   rpc CreateProject(Project.Create) returns (Project);
 
   // Get a project by its id.
@@ -587,6 +650,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not a member of the specified project. |
+  //
+  // @auth
   rpc GetProjectById(Id) returns (Project);
 
   // Update the project with the given id using the provided data. Only
@@ -603,6 +668,8 @@ service SnowballR {
   // | `INVALID_ARGUMENT` | Invalid name, status or project settings specified. |
   // | `PERMISSION_DENIED` | The user is not allowed to update the project. |
   // | `FAILED_PRECONDITION` | The project is not active. |
+  //
+  // @auth
   rpc UpdateProject(Project.Update) returns (Project);
 
   // Export the provided project in the given format. A blob is returned.
@@ -616,6 +683,8 @@ service SnowballR {
   // | `INVALID_ARGUMENT` | The specified format is invalid. |
   // | `NOT_FOUND` | No project with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not a member of the specified project. |
+  //
+  // @auth
   rpc ExportProject(ExportRequest) returns (Blob);
 
   // Mark a project as deleted. It is not fully deleted from the database and
@@ -628,6 +697,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not an admin of the specified project. |
+  //
+  // @auth
   rpc SoftDeleteProject(Id) returns (Nothing);
 
   // Restore a previously deleted project to the **active** state.
@@ -639,6 +710,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not an admin of the specified project. |
+  //
+  // @auth
   rpc SoftUndeleteProject(Id) returns (Nothing);
 
   // Retrieve information about the specified project. Only attributes
@@ -650,6 +723,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not a member of the specified project. |
+  //
+  // @auth
   rpc GetProjectInformation(Project.Information.Get)
       returns (Project.Information);
 
@@ -663,6 +738,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project with the provided id was found or the specified stage does not exist. |
   // | `PERMISSION_DENIED` | The user is not a member of the specified project. |
+  //
+  // @auth
   rpc GetDecisionStatisticsForStage(Project.Information.DecisionStatistics.Get)
       returns (Project.Information.DecisionStatistics);
 
@@ -674,6 +751,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No criterion with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not a member of the project the criterion belongs to. |
+  //
+  // @auth
   rpc GetCriterionById(Id) returns (Criterion);
 
   // Get all criteria associated with a given project.
@@ -684,6 +763,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not a member of the specified project. |
+  //
+  // @auth
   rpc GetAllCriteriaForProject(Id) returns (Criterion.List);
 
   // Create a new criterion. Every field **must be specified** and
@@ -697,6 +778,8 @@ service SnowballR {
   // | `INVALID_ARGUMENT` | At least one field in the provided criterion was blank. |
   // | `NOT_FOUND` | No project with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not an admin of the specified project. |
+  //
+  // @auth
   rpc CreateCriterion(Criterion.Create) returns (Criterion);
 
   // Update the criterion with the given id using the provided data. Only
@@ -711,6 +794,8 @@ service SnowballR {
   // | `NOT_FOUND` | No criterion with the provided id was found. |
   // | `INVALID_ARGUMENT` | At least one field in the provided update was blank. |
   // | `PERMISSION_DENIED` | The user is not an admin of the project the criterion belongs to. |
+  //
+  // @auth
   rpc UpdateCriterion(Criterion.Update) returns (Criterion);
 
   // Permanently delete the specified criterion. All references to it will also
@@ -723,6 +808,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No criterion with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not an admin of the project the criterion belongs to. |
+  //
+  // @auth
   rpc DeleteCriterion(Id) returns (Nothing);
 
   // Get a project paper by its id.
@@ -733,6 +820,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project paper with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not a member of the project the paper belongs to. |
+  //
+  // @auth
   rpc GetProjectPaperById(Id) returns (Project.Paper);
 
   // Get a project paper using the project id and the local id within that
@@ -745,6 +834,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project paper with the provided relative id was found. Either the project does not exist or the relative id was not found within the project. |
   // | `PERMISSION_DENIED` | The user is not a member of the project the paper belongs to. |
+  //
+  // @auth
   rpc GetProjectPaperByRelativeId(Project.Paper.Get) returns (Project.Paper);
 
   // Retrieve all project papers associated with the given project.
@@ -755,6 +846,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not a member of the specified project. |
+  //
+  // @auth
   rpc GetAllProjectPapersForProject(Id) returns (Project.Paper.List);
 
   // Add the provided paper to the given project within the specified stage.
@@ -769,6 +862,8 @@ service SnowballR {
   // | `INVALID_ARGUMENT` | The provided stage does not exist in the project. This could mean that stage was less than zero or greater than `max_stage`. |
   // | `ALREADY_EXISTS` | The specified paper already exists within the provided project. |
   // | `PERMISSION_DENIED` | The user is not part of the specified project or is not a project admin. |
+  //
+  // @auth
   rpc AddPaperToProject(Project.Paper.Add) returns (Project.Paper);
 
   // Update the project paper with the specified id using the provided data.
@@ -784,6 +879,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project paper with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not admin of the project the project paper belongs to. |
+  //
+  // @auth
   rpc UpdateProjectPaper(Project.Paper.Update) returns (Project.Paper);
 
   // Permanently remove the specified project paper from the project. All
@@ -796,6 +893,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `PERMISSION_DENIED` | The user is not an admin of the project the project paper belongs to. |
+  //
+  // @auth
   rpc RemovePaperFromProject(Id) returns (Nothing);
 
   // Get a review by its id.
@@ -806,6 +905,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No review with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not a member of the project the review belongs to. |
+  //
+  // @auth
   rpc GetReviewById(Id) returns (Review);
 
   // Retrieve all reviews for a specific project paper.
@@ -816,6 +917,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No project paper with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is not a member of the project the project paper belongs to. |
+  //
+  // @auth
   rpc GetAllReviewsForProjectPaper(Id) returns (Review.List);
 
   // Create a new review for a specific project paper. Every field must be
@@ -834,6 +937,8 @@ service SnowballR {
   // | `FAILED_PRECONDITION` | The project paper is not in the `UNREVIEWED` or `IN_REVIEW` state. |
   // | `PERMISSION_DENIED` | The user is not a member of the project the project paper belongs to. |
   // | `INVALID_ARGUMENT` | At least one field in the provided review (except for `selected_criteria_ids`) was blank. This could be an invalid `decision` or `selected_criteria_ids`. |
+  //
+  // @auth
   rpc CreateReview(Review.Create) returns (Review);
 
   // Update the review with the given id using the provided data. Only fields
@@ -852,6 +957,8 @@ service SnowballR {
   // | `INVALID_ARGUMENT` | At least one field in the provided update was blank. This could be an invalid `decision` or an empty or invalid `selected_criteria_ids`. |
   // | `PERMISSION_DENIED` | The user is either not the owner of the review or not a member of the project the review belongs to. |
   // | `FAILED_PRECONDITION` | The project paper is in a state where no further review modifications are allowed. |
+  //
+  // @auth
   rpc UpdateReview(Review.Update) returns (Review);
 
   // Permanently remove the specified review from the project paper. **This
@@ -867,6 +974,8 @@ service SnowballR {
   // | `NOT_FOUND` | No review with the provided id was found. |
   // | `PERMISSION_DENIED` | The user is either not the owner of the review or not a member of the project the review belongs to. |
   // | `FAILED_PRECONDITION` | The project paper is in a state where reviews are not allowed to be deleted. |
+  //
+  // @auth
   rpc DeleteReview(Id) returns (Nothing);
 
   // Get a paper by its id.
@@ -876,6 +985,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No paper with the provided id was found. |
+  //
+  // @auth
   rpc GetPaperById(Id) returns (Paper);
 
   // Create a paper using the given data. The `id` will be ignored and set by
@@ -886,6 +997,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `INVALID_ARGUMENT` | At least one field in the provided paper was invalid. |
+  //
+  // @auth
   rpc CreatePaper(Paper) returns (Paper);
 
   // Update the paper with the given id using the provided data. Only
@@ -899,6 +1012,8 @@ service SnowballR {
   // | `NOT_FOUND` | No paper with the provided id was found. |
   // | `INVALID_ARGUMENT` | At least one field in the provided paper was invalid. |
   // | `PERMISSION_DENIED` | The user is not allowed to update the specified paper. |
+  //
+  // @auth
   rpc UpdatePaper(Paper.Update) returns (Paper);
 
   // Get a list of papers that are referred to by the provided paper.
@@ -908,6 +1023,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No paper with the provided id was found. |
+  //
+  // @auth
   rpc GetForwardReferencedPapers(Id) returns (Paper.List);
 
   // Get a list of papers that are referring to the provided paper.
@@ -917,6 +1034,8 @@ service SnowballR {
   // | :--- | :--- |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No paper with the provided id was found. |
+  //
+  // @auth
   rpc GetBackwardReferencedPapers(Id) returns (Paper.List);
 
   // Get a paper's PDF as a blob.
@@ -927,6 +1046,8 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   // | `NOT_FOUND` | No paper with the provided id was found. |
   // | `FAILED_PRECONDITION` | The paper has no PDF attached to it. See [`paper.has_pdf`](#message-snowballr.Paper). |
+  //
+  // @auth
   rpc GetPaperPdf(Id) returns (Blob);
 
   // Set or overwrite the PDF of the specified paper. This call may also be
@@ -940,6 +1061,8 @@ service SnowballR {
   // | `NOT_FOUND` | No paper with the provided id was found. |
   // | `RESOURCE_EXHAUSTED` | The provided PDF was declined by the server. A possible reason could be, that it was too large. |
   // | `INVALID_ARGUMENT` | The provided PDF does not seem to be in the correct format. |
+  //
+  // @auth
   rpc SetPaperPdf(Paper.PdfUpdate) returns (Nothing);
 }
 


### PR DESCRIPTION
Closes #49 

## What I have made

The text visible slightly below the padlock is a tooltip.

<img width="1420" alt="image" src="https://github.com/user-attachments/assets/fa15f35c-7d48-4f10-a508-bea87611055d" />

A call can be marked as "requiring authentication" by including `@auth` in the service method description.

## Checklist

- [x] I have updated the documentation accordingly and commented my code
- [x] (for reviewer) I have checked the implementation against the requirements
