### PR TITLE
docs: show parent types for rpc argument and return type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
 FROM markvincze/sabledocs:0.16.893-slim AS build
+
 WORKDIR /build
 COPY . .
-RUN cd proto && protoc *.proto -o ../descriptor.pb --include_source_info
-RUN pip3 install pypatch markdown-mermaidjs
-RUN pypatch apply ./patches/sabledocs_fix_nested.patch sabledocs
-RUN pypatch apply ./patches/sabledocs_nested_links.patch sabledocs
-RUN pypatch apply ./patches/sabledocs_nested_names.patch sabledocs
-RUN pypatch apply ./patches/sabledocs_fix_arguments.patch sabledocs
-RUN pypatch apply ./patches/markdown_mermaidjs_no_script.patch markdown_mermaidjs
-RUN sabledocs
+
+WORKDIR /build/proto
+RUN protoc ./*.proto -o ../descriptor.pb --include_source_info
+
+WORKDIR /build
+RUN pip3 install pypatch markdown-mermaidjs \
+    && pypatch apply ./patches/sabledocs_fix_nested.patch sabledocs \
+    && pypatch apply ./patches/sabledocs_nested_links.patch sabledocs \
+    && pypatch apply ./patches/sabledocs_nested_names.patch sabledocs \
+    && pypatch apply ./patches/sabledocs_fix_arguments.patch sabledocs \
+    && pypatch apply ./patches/markdown_mermaidjs_no_script.patch markdown_mermaidjs \
+    && sabledocs
 
 FROM nginx AS deploy
+
 COPY --from=build /build/sabledocs_output /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN pip3 install pypatch markdown-mermaidjs
 RUN pypatch apply ./patches/sabledocs_fix_nested.patch sabledocs
 RUN pypatch apply ./patches/sabledocs_nested_links.patch sabledocs
 RUN pypatch apply ./patches/sabledocs_nested_names.patch sabledocs
+RUN pypatch apply ./patches/sabledocs_fix_arguments.patch sabledocs
 RUN pypatch apply ./patches/markdown_mermaidjs_no_script.patch markdown_mermaidjs
 RUN sabledocs
 

--- a/patches/sabledocs_fix_arguments.patch
+++ b/patches/sabledocs_fix_arguments.patch
@@ -1,0 +1,20 @@
+diff --git a/proto_descriptor_parser.py b/proto_descriptor_parser.py
+index 2ee9df7..defa0cc 100644
+--- a/proto_descriptor_parser.py
++++ b/proto_descriptor_parser.py
+@@ -231,13 +231,13 @@ def parse_service_method(service_method: MethodDescriptorProto, ctx: ParseContex
+     sm.description_html = markdown_to_html(sm.description, ctx.config)
+     sm.line_number = ctx.GetLineNumber()
+     sm.request = ServiceMethodArgument(
+-        service_method.input_type[service_method.input_type.rfind(".") + 1:],
++        service_method.input_type.strip(".")[service_method.input_type.strip(".").find(".") + 1:],
+         service_method.input_type.strip("."),
+         "MESSAGE"
+     )
+ 
+     sm.response = ServiceMethodArgument(
+-        service_method.output_type[service_method.output_type.rfind(".") + 1:],
++        service_method.output_type.strip(".")[service_method.output_type.strip(".").find(".") + 1:],
+         service_method.output_type.strip("."),
+         "MESSAGE"
+     )


### PR DESCRIPTION
Closes #62 

## What I have made

Patch sabledocs to use whole type but without the prefix.
Now looks like this:
![image](https://github.com/user-attachments/assets/c6a46c14-cba9-4603-b850-0cf617e043b9)


## Checklist

- [x] I have updated the documentation accordingly and commented my code
- [x] (for reviewer) I have checked the implementation against the requirements
