### PR TITLE
Add project invitation accept call

### DIFF
--- a/proto/main.proto
+++ b/proto/main.proto
@@ -143,9 +143,9 @@ service SnowballR {
   // | `INVALID_ARGUMENT` | At least one input did not meet the requirements. The email needs to be a valid email, the password needs to meet the previously stated criteria and the first and last name must not be blank. |
   rpc Register(RegisterRequest) returns (Nothing);
 
-  // After registering, a user is sent a verification token via email.
+  // After registering, a user receives a verification token via email.
   // This call is used to submit that token, confirming the ownership of the
-  // email address and activating the user account.option
+  // email address and activating the user account.
   //
   // ## Errors
   // | Error Code | Description |

--- a/proto/main.proto
+++ b/proto/main.proto
@@ -523,6 +523,18 @@ service SnowballR {
   // @auth
   rpc InviteUserToProject(Project.Member.Invite) returns (Nothing);
 
+  // Accept a project invitation. After inviting a user to a project, the invited user
+  // receives an email with a link to accept the invitation. This call is used to
+  // accept that invitation.
+  //
+  // ## Errors
+  // | Error Code | Description |
+  // | :--- | :--- |
+  // | `DEADLINE_EXCEEDED` | The provided token is invalid, could not be found or is expired. |
+  // | `FAILED_PRECONDITION` | The user is not registered. |
+  // | `INVALID_ARGUMENT` | No token was provided. |
+  rpc AcceptProjectInvitation(Project.Member.Accept) returns (Nothing);
+
   // Get a list of all users with a pending invitation to the provided project.
   // If the `id` field is specified, it is **guaranteed** that the user exists.
   // If, however, the `id` is blank, the user was invited by email and has not

--- a/proto/project.proto
+++ b/proto/project.proto
@@ -114,6 +114,10 @@ message Project {
       string user_email = 2;
     }
 
+    message Accept {
+      string token = 1;
+    }
+
     message Remove {
       string project_id = 1;
       string user_id = 2;


### PR DESCRIPTION
Closes #76 

## What I have made

- Added a new accept project invitation call
- Removed 'option' word which was wrongfully added in the last merge

Why I chose those error codes:
Since the main idea is the same as with the verification token we also need the deadline exceeded and the invalid argument.
But in addition, the user may click on the link altough he is not yet registered. In this case, the user will be notified he should create an account (then verify), then click on the accepting link.

Imo, this is the easiest solution. I cannot think of another one, that does not completely change the general register process. If you do not agree, please tell me.
If you have any suggestions to make this better, I'm open for improvements.

## Checklist

- [x] I have updated the documentation accordingly and commented my code
- [x] (for reviewer) I have checked the implementation against the requirements
