### PR TITLE
Swap the description of getForwardReferencedPapers and getBackwardReferencedPapers

### DIFF
--- a/proto/main.proto
+++ b/proto/main.proto
@@ -1074,7 +1074,7 @@ service SnowballR {
   // @auth
   rpc UpdatePaper(Paper.Update) returns (Paper);
 
-  // Get a list of papers that are referred to by the provided paper.
+  // Get a list of papers that are referring to the provided paper, i.e. the papers that cite this paper.
   //
   // ## Errors
   // | Error Code | Description |
@@ -1085,7 +1085,7 @@ service SnowballR {
   // @auth
   rpc GetForwardReferencedPapers(Id) returns (Paper.List);
 
-  // Get a list of papers that are referring to the provided paper.
+  // Get a list of papers that are referred to by the provided paper, i.e. the references of this paper.
   //
   // ## Errors
   // | Error Code | Description |


### PR DESCRIPTION
Closes #82 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new call, which does x -->

I swapped the descriptions of the methods `getForwardReferencedPapers` and `getBackwardReferencedPapers`.

## Checklist

- [x] I have updated the documentation accordingly and commented my code
- [x] (for reviewer) I have checked the implementation against the requirements
