### PR TITLE
Replace `user_id` with `user_email` in `Project.Member.Remove` message

### DIFF
--- a/proto/main.proto
+++ b/proto/main.proto
@@ -606,17 +606,17 @@ service SnowballR {
   // @auth
   rpc GetProjectMembers(Id) returns (Project.Member.List);
 
-  // Remove the specified user from the specified project. If the user is not part
+  // Remove the specified user or invitee from the specified project. If the user is not part
   // of the project, nothing happens. The calling user is **required to be a
   // project admin**. If there is only one project admin, then the user cannot be removed from the project.
   //
   // ## Errors
   // | Error Code | Description |
   // | :--- | :--- |
-  // | `INVALID_ARGUMENT` | The project ID or the user ID is not a valid UUID. |
+  // | `INVALID_ARGUMENT` | The project ID is not a valid UUID or the user's email address is not a valid email address. |
   // | `NOT_FOUND` | No project with the provided project ID or user with the provided user ID was found. |
-  // | `PERMISSION_DENIED` | The calling user is neither a server admin nor a project admin of the project, nor the user themselves. |
-  // | `FAILED_PRECONDITION` | The user to be removed is the last project admin in the project. |
+  // | `PERMISSION_DENIED` | The calling user is neither a server admin nor a project admin of the project, nor the project member themselves. |
+  // | `FAILED_PRECONDITION` | The project member to be removed is the last project admin in the project. |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   //
   // @auth

--- a/proto/project.proto
+++ b/proto/project.proto
@@ -120,7 +120,7 @@ message Project {
 
     message Remove {
       string project_id = 1;
-      string user_id = 2;
+      string user_email = 3;
     }
 
     message Update {


### PR DESCRIPTION
Closes #106

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new call, which does x -->

- I updated the `RemoveProjectMember` call to accept an email to find the project member / invitee and remove it, so this call can be used to remove invitations from a project

## Checklist

- [x] I have updated the documentation accordingly and commented my code
- [x] (for reviewer) I have checked the implementation against the requirements
