### PR TITLE
Add notice about duplicate invitations to `InviteUserToProject` call

### DIFF
--- a/proto/main.proto
+++ b/proto/main.proto
@@ -547,8 +547,9 @@ service SnowballR {
   // @auth
   rpc GetInviteCandidates(Project.InviteCandidatesRequest) returns (User.List);
 
-  // Invite a user to a project. The provided project must be active, meaning
-  // it is neither deleted nor archived. An invitation email is sent to the specified email address.
+  // Invite a user to a project. If the user was already invited to the specified project, nothing happens.
+  // The provided project must be active, meaning it is neither deleted nor archived.
+  // An invitation email is sent to the specified email address.
   // The recipient may need to register first and then accept the invitation.
   // The calling user is **required to be a project admin**.
   //


### PR DESCRIPTION
Closes #109 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new call, which does x -->

- I considered the second solution as well (ignoring the second request and do not do anything, if a user is invited to a project twice) and decided to go with that solution.
- I added a note to the `InviteUserToProject` call that in case of a user is invited to a project twice, then nothing happens

## Checklist

- [x] I have updated the documentation accordingly and commented my code
- [x] (for reviewer) I have checked the implementation against the requirements
