### PR TITLE
Correct and extend `INVALID_ARGUMENT` error description of `AddPaperToProject` call

### DIFF
--- a/proto/main.proto
+++ b/proto/main.proto
@@ -978,18 +978,17 @@ service SnowballR {
   rpc GetAllProjectPapersForProject(Id) returns (Project.Paper.List);
 
   // Add the provided paper to the given project at the specified stage.
-  // The stage must be less than or equal to the project's `max_stage`.
+  // The stage must be non-negative and less than or equal to the project's `max_stage`.
   // The calling user is **required to be a project admin**.
   //
   // ## Errors
   // | Error Code | Description |
   // | :--- | :--- |
-  // | `INVALID_ARGUMENT` | The project ID or paper ID is not a valid UUID. |
+  // | `INVALID_ARGUMENT` | The project ID or paper ID is not a valid UUID, or the provided stage either is not a valid number or does not exist in the project, i.e., the stage was less than zero or greater than `max_stage`. |
   // | `NOT_FOUND` | No project with the provided project ID or paper with the provided paper ID was found. |
   // | `ALREADY_EXISTS` | The provided paper already exists within the project. |
   // | `PERMISSION_DENIED` | The calling user is neither a server admin nor a project admin of the project. |
   // | `FAILED_PRECONDITION` | The project is not active (i.e., archived or deleted). |
-  // | `OUT_OF_RANGE` | The provided stage does not exist in the project, i.e., the stage was less than zero or greater than `max_stage`. |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   //
   // @auth


### PR DESCRIPTION
Closes #128

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new call, which does x -->

- I removed the `OUT_OF_RANGE` error in the error table of the `AddPaperToProject` an invalid stage (either not a long number or out of range) is implemented as `INVALID_ARGUMENT` which is also more correct according to the gRPC documentation on error codes

## Checklist

### Author

- [x] I have updated the documentation accordingly and commented my code

### Reviewer

- [ ] I have checked the implementation against the requirements
