### PR TITLE
Extend error description of the `NOT_FOUND` error in the `UpdateCriterion` call

### DIFF
--- a/proto/main.proto
+++ b/proto/main.proto
@@ -911,7 +911,7 @@ service SnowballR {
   // | Error Code | Description |
   // | :--- | :--- |
   // | `INVALID_ARGUMENT` | At least one (updated) criterion detail did not meet the requirements: All fields (except `project_id`) must not be blank and if the `project_id` is given, it must be a valid UUID. |
-  // | `NOT_FOUND` | No criterion with the provided ID was found. |
+  // | `NOT_FOUND` | No criterion with the provided ID was found or a project ID is given but does not refer to an existing project. |
   // | `PERMISSION_DENIED` | If the criterion is a user-criterion, the calling user is not the original creator of the criterion. If the criterion is a project-criterion, the calling user is neither a server admin nor a project admin of the project the criterion belongs to. |
   // | `FAILED_PRECONDITION` | A project ID is given but does not refer to an active project (i.e., it is archived or deleted). |
   // | `UNAUTHENTICATED` | The user is not signed in. |


### PR DESCRIPTION
Closes #127 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new call, which does x -->

## Checklist

- I extended the error description of the `NOT_FOUND` error in the `UpdateCriterion` call because the error description was missing the case, that a project ID is given but the specified project does not exist (according to the backend implementation).


### Author

- [x] I have updated the documentation accordingly and commented my code

### Reviewer

- [ ] I have checked the implementation against the requirements
