### PR TITLE
Use Project.Paper.SearchQuery for SearchLocalPapers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.14.0] - 2026-05-23
+
+### Changed
+
+- Rename `SearchLocalPapers` and `SearchFetcherPapers` to `SearchLocalProjectPaperCandidates` and `SearchFetcherProjectPaperCandidates`, respectively, to clarify that the search results are filtered for papers that are not yet added to the project ([#160](https://github.com/SE-UUlm/snowballr-api/issues/160)) (Felix Schlegel)
+
+### Added
+
+- Add `project_id` to `Paper.SearchQuery` ([#160](https://github.com/SE-UUlm/snowballr-api/issues/160)) (Felix Schlegel)
+
 ## [0.13.3] - 2026-04-02
 
 ### Fixed
@@ -196,6 +206,8 @@
 ## [0.1.0] - 2025-01-30
 
 _:seedling: Initial release._
+
+[0.14.0]: https://github.com/SE-UUlm/snowballr-api/releases/tag/v0.14.0
 
 [0.13.3]: https://github.com/SE-UUlm/snowballr-api/releases/tag/v0.13.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Changed
 
-- Rename `SearchLocalPapers` and `SearchFetcherPapers` to `SearchLocalProjectPaperCandidates` and `SearchFetcherProjectPaperCandidates`, respectively, to clarify that the search results are filtered for papers that are not yet added to the project ([#160](https://github.com/SE-UUlm/snowballr-api/issues/160)) (Felix Schlegel)
+- **Breaking:** Use `Project.Paper.SearchQuery` as request type for `SearchLocalPapers` ([#160](https://github.com/SE-UUlm/snowballr-api/issues/160)) (Felix Schlegel)
+- **Breaking:** Rename `SearchLocalPapers` and `SearchFetcherPapers` to `SearchLocalProjectPaperCandidates` and `SearchFetcherProjectPaperCandidates`, respectively, to clarify that the search results are filtered for papers that are not yet added to the project ([#160](https://github.com/SE-UUlm/snowballr-api/issues/160)) (Felix Schlegel)
 
-### Added
+### Removed
 
-- Add `project_id` to `Paper.SearchQuery` ([#160](https://github.com/SE-UUlm/snowballr-api/issues/160)) (Felix Schlegel)
+- Remove `Paper.SearchQuery` message ([#160](https://github.com/SE-UUlm/snowballr-api/issues/160)) (Felix Schlegel)
 
 ## [0.13.3] - 2026-04-02
 

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "snowballr-api",
-    "version": "0.13.3",
+    "version": "0.14.0",
     "description": "API for the SnowballR Web Application.",
     "main": "dist/",
     "type": "module",

--- a/proto/main.proto
+++ b/proto/main.proto
@@ -1127,7 +1127,7 @@ service SnowballR {
   // | `UNAUTHENTICATED` | The user is not signed in. |
   //
   // @auth
-  rpc SearchLocalProjectPaperCandidates(Paper.SearchQuery) returns (Paper.List);
+  rpc SearchLocalProjectPaperCandidates(Project.Paper.SearchQuery) returns (Paper.List);
 
   // Search for papers that match the search query using all available fetchers
   // of the specified project in order to find candidates for addition to the

--- a/proto/main.proto
+++ b/proto/main.proto
@@ -1103,29 +1103,61 @@ service SnowballR {
   // @auth
   rpc GetPaperById(Id) returns (Paper);
 
-  // Search the local database for papers using a search string.
+  // Search the local database for papers using a search string in order to find
+  // candidates for addition to the specified project. The search is performed
+  // only within the papers that are already in the local database and not yet
+  // added to the specified project.
+  //
+  // The client can use these search results to add papers to the project using
+  // the [AddPaperToProject](#service-snowballr.SnowballR-AddPaperToProject)
+  // call.
+  //
+  // There are no restrictions on the search query in terms of valid values,
+  // except the length.
+  // The backend is fully responsible for deciding which paper attributes the
+  // query is matched against and is supposed to provide the best results for
+  // the given query.
   //
   // ## Errors
   // | Error Code | Description |
   // | :--- | :--- |
-  // | `UNAUTHENTICATED` | The user is not signed in. |
-  //
-  // @auth
-  rpc SearchLocalPapers(Paper.SearchQuery) returns (Paper.List);
-
-  // Search for papers that match the search query using all available fetchers of
-  // the specified project.
-  //
-  // ## Errors
-  // | Error Code | Description |
-  // | :--- | :--- |
-  // | `INVALID_ARGUMENT` | The project ID is not a valid UUID. |
-  // | `NOT_FOUND` | No project with the provided id was found. |
+  // | `INVALID_ARGUMENT` | The project ID is not a valid UUID or the search query is either blank or exceeds its maximum length. |
+  // | `NOT_FOUND` | No project with the provided ID was found. |
   // | `PERMISSION_DENIED` | The calling user is neither a server admin nor a member of the specified project. |
   // | `UNAUTHENTICATED` | The user is not signed in. |
   //
   // @auth
-  rpc SearchFetcherPapers(Project.Paper.SearchQuery) returns (Paper.List);
+  rpc SearchLocalProjectPaperCandidates(Paper.SearchQuery) returns (Paper.List);
+
+  // Search for papers that match the search query using all available fetchers
+  // of the specified project in order to find candidates for addition to the
+  // project. The search is performed only on papers that are found by the
+  // fetchers, but not yet added to the specified project.
+  //
+  // Fetcher papers that already exist in the local database include their
+  // respective IDs, while papers that do not exist have an empty `id` field in
+  // the search results. The client can use this information to first add papers
+  // that do not exist in the local database to the database using the
+  // [CreatePaper](#service-snowballr.SnowballR-CreatePaper) call and then add
+  // them to the project using the
+  // [AddPaperToProject](#service-snowballr.SnowballR-AddPaperToProject) call.
+  //
+  // There are no restrictions on the search query in terms of valid values,
+  // except the length.
+  // The backend is fully responsible for deciding which paper attributes the
+  // query is matched against and is supposed to provide the best results for
+  // the given query.
+  //
+  // ## Errors
+  // | Error Code | Description |
+  // | :--- | :--- |
+  // | `INVALID_ARGUMENT` | The project ID is not a valid UUID or the search query is either blank or exceeds its maximum length. |
+  // | `NOT_FOUND` | No project with the provided ID was found. |
+  // | `PERMISSION_DENIED` | The calling user is neither a server admin nor a member of the specified project. |
+  // | `UNAUTHENTICATED` | The user is not signed in. |
+  //
+  // @auth
+  rpc SearchFetcherProjectPaperCandidates(Project.Paper.SearchQuery) returns (Paper.List);
 
   // Create a new paper. The `id` field will be ignored and set by
   // the server. The created paper is returned and **guaranteed to be specified**.

--- a/proto/paper.proto
+++ b/proto/paper.proto
@@ -53,5 +53,7 @@ message Paper {
     // query is matched against and is supposed to provide the best results for
     // the given query.
     string query = 2;
+
+    string project_id = 3;
   }
 }

--- a/proto/paper.proto
+++ b/proto/paper.proto
@@ -45,15 +45,4 @@ message Paper {
     string paper_id = 1;
     Blob pdf = 2;
   }
-
-  // Request to search for papers according to a query.
-  message SearchQuery {
-    // There are no restrictions on this search query in terms of valid values.
-    // The backend is fully responsible for deciding which paper attributes this
-    // query is matched against and is supposed to provide the best results for
-    // the given query.
-    string query = 2;
-
-    string project_id = 3;
-  }
 }

--- a/proto/project.proto
+++ b/proto/project.proto
@@ -220,7 +220,8 @@ message Project {
     // Request to search for project papers according to a query.
     message SearchQuery {
       string project_id = 1;
-      // There are no restrictions on this search query in terms of valid values.
+      // There are no restrictions on this search query in terms of valid values,
+      // except the length.
       // The backend is fully responsible for deciding which paper attributes this
       // query is matched against and is supposed to provide the best results for
       // the given query.


### PR DESCRIPTION
Closes #160

## What I have made

- SearchLocalPapers now uses Project.Paper.SearchQuery so it can access the project_id
- renamed both search calls for clarification
- already added the CHANGELOG entry

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code

### Reviewer

- [x] I have checked the changes against the requirements
