### PR TITLE
Provide more information for a single fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.15.0] - 2026-06-29
+
+### Changed
+
+- Replace `AvailableFetchers.fetcher_names` with `AvailableFetchers.fetchers` (repeated `FetcherInformation`) to provide richer fetcher metadata ([#164](https://github.com/SE-UUlm/snowballr-api/issues/164)) (Felix Schlegel)
+
+### Added
+
+- Add `FetcherInformation` message with `id`, `name`, `description`, `links`, and `options_schema` fields to describe a fetcher and enable UI generation ([#164](https://github.com/SE-UUlm/snowballr-api/issues/164)) (Felix Schlegel)
+- Add `FetcherOptionSchema` message to describe individual fetcher options, including `name`, `description`, `required`, `is_secret`, and `default_value` ([#164](https://github.com/SE-UUlm/snowballr-api/issues/164)) (Felix Schlegel)
+- Add `Link` message to `base.proto` for labeled URLs ([#164](https://github.com/SE-UUlm/snowballr-api/issues/164)) (Felix Schlegel)
+
+### Removed
+
+- Remove `GetAvailableFetcherOptions` RPC; option schema is now embedded in `FetcherInformation.options_schema` ([#164](https://github.com/SE-UUlm/snowballr-api/issues/164)) (Felix Schlegel)
+- Remove `GetAvailableFetcherOptionsRequest` message ([#164](https://github.com/SE-UUlm/snowballr-api/issues/164)) (Felix Schlegel)
+
 ## [0.14.0] - 2026-05-23
 
 ### Changed
@@ -207,6 +224,8 @@
 ## [0.1.0] - 2025-01-30
 
 _:seedling: Initial release._
+
+[0.15.0]: https://github.com/SE-UUlm/snowballr-api/releases/tag/v0.15.0
 
 [0.14.0]: https://github.com/SE-UUlm/snowballr-api/releases/tag/v0.14.0
 

--- a/proto/base.proto
+++ b/proto/base.proto
@@ -26,3 +26,9 @@ message BoolValue {
 message Blob {
   bytes data = 1;
 }
+
+// A link with a label and a URL.
+message Link {
+  string label = 1;
+  string url = 2;
+}

--- a/proto/fetcher.proto
+++ b/proto/fetcher.proto
@@ -2,19 +2,46 @@
 
 syntax = "proto3";
 package snowballr;
+import "base.proto";
 
 // Response of available fetchers.
 message AvailableFetchers {
-  repeated string fetcher_names = 1;
-}
-
-// Request to get all available fetchers.
-message GetAvailableFetcherOptionsRequest {
-  string fetcher_name = 1;
+  repeated FetcherInformation fetchers = 2;
 }
 
 // Options that are used by a fetcher to control behavior.
 message FetcherOptions {
   // Map the option name to a (default) value
   map<string, string> options = 1;
+}
+
+// Information about a fetcher, which can be used to generate a UI for it.
+message FetcherInformation {
+  // The unique identifier of the fetcher. This is used to identify the fetcher.
+  string id = 1;
+  // A human readable name of the fetcher.
+  string name = 2;
+  // A description of the fetcher, which can be used to generate a UI for it.
+  string description = 3;
+  // A list of links related to this fetcher, e.g. documentation or source code.
+  repeated Link links = 4;
+  // A map of option name to its schema, which describes the option and can be used to generate a
+  // UI for it. Also used to validate the options provided by the user when using the fetcher.
+  map<string, FetcherOptionSchema> options_schema = 5;
+}
+
+// Schema for a fetcher option, which describes the option and can be used to generate a UI for it.
+message FetcherOptionSchema {
+  // A human readable name of the option.
+  string name = 1;
+  // A description of the option, which can be used to generate a UI for it.
+  string description = 2;
+  // Whether this option is required or not. If an option is required, it must be provided by the
+  // user when using the fetcher.
+  bool required = 3;
+  // Whether this option is secret or not. If an option is secret, it should be handled with care
+  // and not be exposed in logs and obfuscated in the UI.
+  bool is_secret = 4;
+  // An optional default value for this option.
+  optional string default_value = 5;
 }

--- a/proto/main.proto
+++ b/proto/main.proto
@@ -125,7 +125,7 @@ import "user_settings.proto";
 //
 service SnowballR {
   // Get all available fetchers from which a paper may be sourced by the backend.
-  // Each source is identified by a unique string and is later used to specify
+  // Each source is identified by a unique ID and is later used to specify
   // which APIs will be used by a project to collect papers. The list is
   // **guaranteed to be non-empty** but **may change** at any time.
   //
@@ -136,19 +136,6 @@ service SnowballR {
   //
   // @auth
   rpc GetAvailableFetchers(Nothing) returns (AvailableFetchers);
-
-  // Get all available options for the specified fetcher. The names and
-  // default values of the available options are returned as a string map.
-  // Each option name **can only appear once**. Note that there may be no available options.
-  //
-  // ## Errors
-  // | Error Code | Description |
-  // | :--- | :--- |
-  // | `NOT_FOUND` | The fetcher with the provided name was not found. |
-  // | `UNAUTHENTICATED` | The user is not signed in. |
-  //
-  // @auth
-  rpc GetAvailableFetcherOptions(GetAvailableFetcherOptionsRequest) returns (FetcherOptions);
 
   // Create an account. The provided email address **must not already be registered**,
   // and no field may be blank. If successful, login tokens are


### PR DESCRIPTION
Closes #164 

## What I have made

As discussed in https://github.com/SE-UUlm/snowballr-backend/issues/529, `GetAvailableFetcher` received more information that can be used by the frontend to create a UI and make it easier to handle and validate the options.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code

### Reviewer

- [x] I have checked the changes against the requirements
