### PR TITLE
Add job to check version consistency between CHANGELOG and package.json

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -37,3 +37,21 @@ jobs:
                   source-branch: main
                   ignore-links: "https://github.com/SE-UUlm/snowballr-api/releases/tag/*,https://www.npmjs.com/package/snowballr-api"
                   ignore-paths: "docs/,patches/,proto/,AGENTS.md,CLAUDE.md"
+
+    check-version-consistency:
+        name: Check version consistency
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Check that CHANGELOG version matches package.json version
+              run: |
+                  CHANGELOG_VERSION=$(grep -m 1 '## \[' CHANGELOG.md | sed 's/## \[\(.*\)\].*/\1/')
+                  PACKAGE_VERSION=$(jq -r '.version' npm-package/package.json)
+                  echo "CHANGELOG version: $CHANGELOG_VERSION"
+                  echo "package.json version: $PACKAGE_VERSION"
+                  if [ "$CHANGELOG_VERSION" != "$PACKAGE_VERSION" ]; then
+                      echo "Error: version mismatch (CHANGELOG.md: $CHANGELOG_VERSION, package.json: $PACKAGE_VERSION)"
+                      exit 1
+                  fi


### PR DESCRIPTION
Closes #168

## What I have made

Added a `check-version-consistency` job to the `Linting` workflow that extracts the latest version from `CHANGELOG.md` and compares it to the version in `npm-package/package.json`, failing if they differ. This ensures the release procedure is followed correctly on every PR and push to `main`.

## Checklist

Either tick or cross out the items that do not apply (using ~~example text~~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code ~~(no code/docs changes — CI-only)~~

### Reviewer

- [x] I have checked the changes against the requirements