### PR TITLE
Add external IDs to paper message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.16.0] - 2026-07-16
+
+### Changed
+
+- **Breaking:** Replace `external_id` field in `Paper` message with `external_ids` repeated field to support multiple external IDs ([#166](https://github.com/SE-UUlm/snowballr-api/issues/166)) (Felix Schlegel)
+
+### Added
+
+- Add `ExternalId` message with `type` and `value` fields ([#166](https://github.com/SE-UUlm/snowballr-api/issues/166)) (Felix Schlegel)
+
 ## [0.15.0] - 2026-06-29
 
 ### Changed
@@ -224,6 +234,8 @@
 ## [0.1.0] - 2025-01-30
 
 _:seedling: Initial release._
+
+[0.16.0]: https://github.com/SE-UUlm/snowballr-api/releases/tag/v0.16.0
 
 [0.15.0]: https://github.com/SE-UUlm/snowballr-api/releases/tag/v0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- Add `ExternalId` message with `type` and `value` fields ([#166](https://github.com/SE-UUlm/snowballr-api/issues/166)) (Felix Schlegel)
+- Add `ExternalId` message with `type`, `display_type`, and `value` fields ([#166](https://github.com/SE-UUlm/snowballr-api/issues/166)) (Felix Schlegel)
 
 ## [0.15.0] - 2026-06-29
 

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "snowballr-api",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "description": "API for the SnowballR Web Application.",
     "main": "dist/",
     "type": "module",

--- a/proto/paper.proto
+++ b/proto/paper.proto
@@ -51,7 +51,9 @@ message Paper {
   message ExternalId {
     // The type of the external ID, e.g. DOI, URL, ...
     string type = 1;
+    // The display type of the external ID, e.g. DOI, URL, ...
+    string display_type = 2;
     // The actual value of the ID that can be used to identify the paper
-    string value = 2;
+    string value = 3;
   }
 }

--- a/proto/paper.proto
+++ b/proto/paper.proto
@@ -15,7 +15,7 @@ message Author {
 // A scientific paper with it's references and other metadata.
 message Paper {
   string id = 1;
-  string external_id = 2;
+  reserved 2;
   string title = 3;
   string abstrakt = 4;
   int32 year = 5;
@@ -28,6 +28,7 @@ message Paper {
   // A key-value map to store arbitrary metadata about the paper.
   // This could for example be a fetcher specific id.
   map<string, string> fetcher_metadata = 12;
+  repeated ExternalId external_ids = 13;
 
   // A list of papers.
   message List {
@@ -44,5 +45,13 @@ message Paper {
   message PdfUpdate {
     string paper_id = 1;
     Blob pdf = 2;
+  }
+
+  // External ID of a paper, e.g. DOI, URL, etc. that can be used to identify the paper.
+  message ExternalId {
+    // The type of the external ID, e.g. DOI, URL, ...
+    string type = 1;
+    // The actual value of the ID that can be used to identify the paper
+    string value = 2;
   }
 }


### PR DESCRIPTION
Closes #166 

## What I have made

- added `ExternalId` message that replaces the single external_id string in the `Paper` message.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code

### Reviewer

- [x] I have checked the changes against the requirements
