### PR TITLE
Add conventional commit and branch checks from snowballr-ci

### DIFF
--- a/.github/workflows/git_conventions.yml
+++ b/.github/workflows/git_conventions.yml
@@ -20,3 +20,30 @@ jobs:
               uses: SE-UUlm/snowballr-ci/src/ensure-linear-history@v1
               with:
                   target-branch: main
+
+    ensure-conventional-commits:
+        name: Ensure Conventional Commits
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+                  ref: ${{ github.head_ref }}
+
+            - name: Run Check
+              uses: SE-UUlm/snowballr-ci/src/ensure-conventional-commits@v1
+              with:
+                  target-branch: main
+
+    ensure-conventional-branches:
+        name: Ensure Conventional Branches
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
+
+            - name: Run Check
+              uses: SE-UUlm/snowballr-ci/src/ensure-conventional-branches@v1
+              with:
+                  branch-name: ${{ github.head_ref }}


### PR DESCRIPTION
Closes #172

Adds `ensure-conventional-commits` and `ensure-conventional-branches` to `git_conventions.yml`, alongside the existing `ensure-linear-history` job.

**Temporary:** the two new jobs are pinned to `snowballr-ci`'s `feat/25-feature-add-more-git-conventions` branch (not yet released) so we can verify they behave correctly on this repo's real PRs before `snowballr-ci` cuts a release. Once released, update both refs to a proper version tag (e.g. `@v1`).